### PR TITLE
Aaron's changes that haven't made it into the central repository yet.

### DIFF
--- a/fizeau/calc_bispect.pro
+++ b/fizeau/calc_bispect.pro
@@ -321,7 +321,13 @@ for i=0, n_runs-1 do begin
     endif
     print, 'Doing Fourier Transforms for file: ',filename
     for k = 0, n_frames-1 do begin
+        currentexcept = !Except
+        !Except=0
+        void=Check_math()
         ft_cube[*,*,k] = fft(shift(cube[*,*,k], -dimx/2,  -dimy/2)*window, 1)
+        stats = check_math()
+        if (stats AND NOT 32) ne 0 then print, 'MATH CHECK ISSUE HERE ' + strtrim(stats,2) 
+        !except = currentexcept
         if (showps eq 1) then begin
             temp =  modsq(ft_cube[0, 0, k])/10.
             image_cont, shift(modsq(ft_cube[*,*,k]) < temp,dimx/2,dimy/2)^0.5, /noc
@@ -338,11 +344,16 @@ for i=0, n_runs-1 do begin
         ft_cube[0, 0, *] -= total(ft_dcube[0, 0, *])/float(n_dframes) ;As this is used for bias subtraction in bispect
     endif else dps = fltarr(dimx,dimy)
     print, 'Now calculating bispectrum...'
+    currentexcept = !Except
+    !Except=0
+    void=Check_math()
     bispect, ft_cube, mf_pvct, mf_gvct, mf_ix, mf_rmat, mf_imat, v2, v2_cov, bs,bs_var, bs_cov, bs_v2_cov, $
       bl2h_ix, bs2bl_ix,bl2bs_ix, bscov2bs_ix, cp_var, bs_all, v2_all, cvis_all, fluxes=fluxes, dark_ps=dps,n_blocks = n_blocks, cp_cov = cp_cov, $
       avar=avar, err_avar=err_avar, imsize = imsize, v2_arr=v2_arr, phs_v2corr = phs_v2corr,  $
       hole_phs = hole_phs,  hole_err_phs = hole_err_phs,hole_piston = hole_piston, subtract_bs_bias = subtract_bs_bias
-
+    stats = check_math()
+    if (stats AND NOT 32) ne 0 then print, 'MATH CHECK ISSUE HERE ' + strtrim(stats,2) 
+    !except = currentexcept
     !p.multi = [0,3,1]
     ; !p.multi = [0,2,1]
     in = indgen(n_baselines)

--- a/fizeau/calibrate_v2_cp.pro
+++ b/fizeau/calibrate_v2_cp.pro
@@ -219,7 +219,7 @@ pro calibrate_v2_cp, cubeinfo_file,  root_dir=root_dir, reset = reset, apply_phs
                      skip_baseline_rejection = skip_baseline_rejection,  v2div = v2div, $
                      special=special, skip_cp_rejection = skip_cp_rejection, bsdir=bsdir, $
                      cal_cp_inspect=cal_cp_inspect, reject_lowv2=reject_lowv2, see_all=see_all,$
-                     freeze=freeze, disp_fit_file=disp_fit_file
+                     freeze=freeze, disp_fit_file=disp_fit_file,starlist=starlist
 
 ;; Now set the default root_dir if we can
 defsysv, '!ROOT_DIR', exists=exists
@@ -250,7 +250,7 @@ cubedates =  olog.cube_fname[*, 1]
 
 ; Add target names if necessary
 if keyword_set(add_names) then begin
-    fill_source_name, olog
+    fill_source_name, olog,starlist=starlist
 endif
 
 if (not keyword_set(linear_v2_cut)) then linear_v2_cut = 0

--- a/fizeau/conica/makedithersky_conica.pro
+++ b/fizeau/conica/makedithersky_conica.pro
@@ -84,7 +84,7 @@ for i=0,nsky-1 do begin
   aframe =  dcube[*, *, i] 
   if (keyword_set(medsub)) then aframe -= medcube
   if(keyword_set(gain)) then aframe=aframe-gain*median(aframe)
-  temp = (smooth(aframe,nint(swidth),/edge))[swidth:dimx-swidth, swidth:dimy-swidth]
+  temp = (smooth(aframe,nint(swidth),/edge_truncate))[swidth:dimx-swidth, swidth:dimy-swidth]
   ;; Find the star (or first polarisation) on the chip
   mx1=max(temp,mxy1)
   mxy1 = array_indices(temp, mxy1)

--- a/fizeau/conica/qball_conica.pro
+++ b/fizeau/conica/qball_conica.pro
@@ -102,7 +102,8 @@ pro dataanalysis_init, queuejobs, manual, parent
   ; expand the updown term in qbeflags...
   qbeflags = (*m.qbeflags)[thisblock]
   loc = strpos(qbeflags, "updown")+7
-  udformat ="('['"+string(n_elements(frames),format="(I03)")+"(I1,:,','))"
+  udformat ="('['"+string(n_elements(frames),format="(I04)")+"(I1,:,','))"
+ ; stop
   expupdown = string(replicate(strmid(qbeflags, loc, 1),n_elements(frames)), format=udformat)+']'
   qbeflags =  strmid(qbeflags, 0, loc) + expupdown + strmid(qbeflags, loc+1, strlen(qbeflags))
   data_dir=dc.data_dir
@@ -726,7 +727,7 @@ pro newblock_ev, ev
 	          *m.bingridflags      = [*m.bingridflags,""]
           endelse
           for s=0, n_stars_thisclump-1 do begin 
-            zvect=intarr(100)
+            zvect=intarr(1000)
             flagvect=intarr(10)
             nstarfiles=m.filenumlimits[1,thisclump[s]]-m.filenumlimits[0,thisclump[s]]+1
             thisfilevect=indgen(nstarfiles) + m.filenumlimits[0,thisclump[s]]
@@ -2301,7 +2302,7 @@ if(dc.markup_sw eq 0) then begin
 	for i=0,n_files-1 do begin
 	  filename=file(i)
 	  head=headfits(filename)
-		 
+          print, file[i]
 	  for j=0,n_elements(s_par)-1 do s_output(j,i)=sxpar_conica(head,s_par(j))
 	  for j=0,n_elements(n_par)-1 do n_output(j,i)=sxpar_conica(head,n_par(j))
 

--- a/fizeau/nearby_cal4src.pro
+++ b/fizeau/nearby_cal4src.pro
@@ -1,0 +1,60 @@
+;;script to make each target only get calibrated by nearby calibrators
+;;in time. 
+
+;;Made by ACR 01/2015
+;;Updated many times since
+
+;; Inputs:
+;; cal4src: the cal4src variable calibrate_v2_cp.pro outputs
+;; npos   : the number of nearby calibrator observations on each side of the
+;; target observations that you want to use
+;; information=information: outputs info on which object is a
+;; calibrator (not tested really)
+;;
+;; Outputs: A new cal4src variable with the new configuration, has
+;; same shape as cal4src
+;;
+;;USE:
+;;qbe_nirc2/qbe_conica
+;;cal_bispec
+;;calibrate_v2_cp with all cals selected top build the basic cal4src array
+;;new_cal4src = nearby_cal4src(cal4src,npos)
+;;calibrate_v2_cp,.......,cal4src = new_cal4src
+;;binary_grid......
+
+
+function nearby_cal4src,cal4src,npos,information=information
+information = strarr(n_elements(cal4src[0,*]))
+;;keep for saving purposes
+ocal4src = cal4src
+for i=0,n_elements(cal4src[0,*])-1 do begin
+   ;;Figure out where the targets are, they should be the only part of
+   ;;the arrays with something other than zero
+   if max(cal4src[*,i]) gt 0 then begin
+      information[i] = 'src'
+      cals = where(cal4src[*,i] eq 1)
+      adist = cals-i
+      spotu = where(adist gt 0)
+      spotl = where(adist lt 0)
+      ucals = cals[spotu]
+      lcals = cals[spotl]
+      ;;reset cal4src
+      cal4src[*,i] = 0
+     ; if i eq 9 then stop
+      if spotu[0] gt -1 then begin
+         sortu = sort(abs(adist[spotu]))
+         nearestu = ucals[sortu[0:npos-1]]
+         cal4src[nearestu,i] = 1
+      endif
+      if spotl[0] gt -1 then begin
+         sortl = sort(abs(adist[spotl]))
+         nearestl = lcals[sortl[0:npos-1]]
+         cal4src[nearestl,i] = 1
+      endif
+     ;if i eq 9 then stop
+   endif else information[i] = 'cal'
+endfor
+
+;stop
+return, cal4src
+end

--- a/fizeau/nirc/skygauss.pro
+++ b/fizeau/nirc/skygauss.pro
@@ -13,14 +13,33 @@ Amp=Area/(sqrt(2.0*!pi)*sigma)
 
 f=Amp*exp(-.5*(X-disp)*(x-disp)/(sigma*sigma))
 pder=fltarr(n_elements(x),3)
-for i=0,n_elements(x)-1 do begin
-;Area
-  pder(i,0)=f(i)/Area
-;Disp
-  pder(i,1)=f(i)*(x(i)-disp)/(sigma*sigma)
-;Sigma
-  pder(i,2)=(-1.0*f(i)/sigma)+(f(i)*(x(i)-disp)*(x(i)-disp)/(sigma^3))
 
-endfor
+
+;;!!!ACR old loop version that's too slow
+;for i=0,n_elements(x)-1 do begin
+;Area
+;  pder(i,0)=f(i)/Area
+;Disp
+;  pder(i,1)=f(i)*(x(i)-disp)/(sigma*sigma)
+;Sigma
+;  pder(i,2)=(-1.0*f(i)/sigma)+(f(i)*(x(i)-disp)*(x(i)-disp)/(sigma^3))
+;;endfor
 ;I hope this doesn't take too long to do..
+
+;;!!!ACR's matrix version with math error catch that supresses
+;;flaoting underflows from being printed to screen
+currentexcept = !Except
+!Except=0
+void=Check_math()
+;;Area
+pder[*,0] = f/Area
+;;Disp
+pder[*,1] = f*(x-disp)/sigma^2
+;;Sigma
+pder[*,2] = -f/sigma+f*(x-disp)^2/sigma^3
+stats = check_math()
+if (stats AND NOT 32) ne 0 then print, 'MATH CHECK ISSUE HERE ' + strtrim(stats,2) 
+!except = currentexcept
+
+
 end

--- a/misc/ic_jdm.pro
+++ b/misc/ic_jdm.pro
@@ -1,0 +1,119 @@
+; $Id: image_cont.pro,v 1.1.1.1 2005/12/19 05:15:05 mireland Exp $
+
+pro ic_jdm, a, WINDOW_SCALE = window_scale, ASPECT = aspect, $
+	INTERP = interp, nocontours=nocontours,xval=x,yval=y,xtit=xtit,$
+        ytit=ytit,$
+        tit=tit
+;+
+; NAME:
+;	IMAGE_CONT
+;
+; PURPOSE:
+;	Overlay an image and a contour plot.
+;
+; CATEGORY:
+;	General graphics.
+;
+; CALLING SEQUENCE:
+;	IMAGE_CONT, A
+;
+; INPUTS:
+;	A:	The two-dimensional array to display.
+;
+; KEYWORD PARAMETERS:
+; WINDOW_SCALE:	Set this keyword to scale the window size to the image size.
+;		Otherwise, the image size is scaled to the window size.
+;		This keyword is ignored when outputting to devices with 
+;		scalable pixels (e.g., PostScript).
+;
+;	ASPECT:	Set this keyword to retain the image's aspect ratio.
+;		Square pixels are assumed.  If WINDOW_SCALE is set, the 
+;		aspect ratio is automatically retained.
+;
+;	INTERP:	If this keyword is set, bilinear interpolation is used if 
+;		the image is resized.
+;
+; OUTPUTS:
+;	No explicit outputs.
+;
+; COMMON BLOCKS:
+;	None.
+;
+; SIDE EFFECTS:
+;	The currently selected display is affected.
+;
+; RESTRICTIONS:
+;	None.
+;
+; PROCEDURE:
+;	If the device has scalable pixels, then the image is written over
+;	the plot window.
+;
+; MODIFICATION HISTORY:
+;	DMS, May, 1988.
+;       JDM, 1996.       Added nocontour keyword, and 
+;  			 changed tv--> tvscl in one subroutine
+;-
+
+on_error,2                      ;Return to caller if an error occurs
+sz = size(a)			;Size of image
+if (keyword_set(x) eq 0) then x=findgen(sz(1))
+if (keyword_set(y) eq 0) then y=findgen(sz(2))
+if (keyword_set(tit) eq 0) then tit=' '
+if (keyword_set(xtit) eq 0) then xtit=' '
+if (keyword_set(ytit) eq 0) then ytit=' '
+ 
+if sz(0) lt 2 then message, 'Parameter not 2D'
+
+	;set window used by contour
+contour,[[0,0],[1,1]],/nodata, xstyle=4, ystyle = 4
+
+px = !x.window * !d.x_vsize	;Get size of window in device units
+py = !y.window * !d.y_vsize
+swx = px(1)-px(0)		;Size in x in device units
+swy = py(1)-py(0)		;Size in Y
+six = float(sz(1))		;Image sizes
+siy = float(sz(2))
+aspi = six / siy		;Image aspect ratio
+aspw = swx / swy		;Window aspect ratio
+f = aspi / aspw			;Ratio of aspect ratios
+
+if (!d.flags and 1) ne 0 then begin	;Scalable pixels?
+  if keyword_set(aspect) then begin	;Retain aspect ratio?
+				;Adjust window size
+	if f ge 1.0 then swy = swy / f else swx = swx * f
+	endif
+  tvscl,a,px(0),py(0),xsize = swx, ysize = swy, /device
+
+endif else begin	;Not scalable pixels	
+   if keyword_set(window_scale) then begin ;Scale window to image?
+	tvscl,a,px(0),py(0)	;Output image
+	swx = six		;Set window size from image
+	swy = siy
+    endif else begin		;Scale window
+	if keyword_set(aspect) then begin
+		if f ge 1.0 then swy = swy / f else swx = swx * f
+		endif		;aspect
+; I changed the following line to read 'tvscl,...' instead of 'tv,...'
+;     --JDM 11/19/96
+	tvscl,poly_2d(bytscl(a),$	;Have to resample image
+		[[0,0],[six/swx,0]], [[0,siy/swy],[0,0]],$
+		keyword_set(interp),swx,swy), $
+		px(0),py(0)
+	endelse			;window_scale
+  endelse			;scalable pixels
+skipimage:
+mx = !d.n_colors-1		;Brightest color
+colors = [mx,mx,mx,0,0,0]	;color vectors
+if !d.name eq 'PS' then colors = mx - colors ;invert line colors for pstscrp
+if (keyword_set(nocontours) eq 0) then $
+contour,a,x,y,/noerase,/xst,/yst,$	;Do the contour
+	   pos = [px(0),py(0), px(0)+swx,py(0)+swy],/dev,$
+	c_color =  colors ,xtit=xtit,ytit=ytit,tit=tit $
+else contour,a,x,y,/noerase,/xst,/yst,$  ;Do the contour
+           pos = [px(0),py(0), px(0)+swx,py(0)+swy],/dev,$
+        c_color =  colors ,/nodata,xtit=xtit,ytit=ytit,tit=tit
+
+
+return
+end

--- a/util/binary_grid.pro
+++ b/util/binary_grid.pro
@@ -398,6 +398,8 @@ if (keyword_set(nosim) eq 0) then begin
   ;unitary = transpose(unitary)
  endif
  tp = transpose(proj)
+;;!!!ACR precalculate this because it takes ages and only has to be done once
+ precalc_dmmodcp = dm#modcp
  tbegin =  systime(1)
  for k = 0, nsim-1 do begin
      if (proj[0] ne -1) then begin
@@ -409,8 +411,12 @@ if (keyword_set(nosim) eq 0) then begin
          if (cp_cinv_null[0] eq -1) then t3sim.t3phi =  cperr_null*randomn(seed, nphi) $
          else t3sim.t3phi = unitary#diag#randomn(seed, nphi)
           ;;*** Are you MJI? If not you only care about the following line(4) *** 
-         crats = 1./reform(params[2, *, *])*reform(t3sim.t3phi#dm#modcp, nr, nang)/norm
-     endelse
+         crats  = 1./reform(params[2, *, *])*reform(t3sim.t3phi#precalc_dmmodcp, nr, nang)/norm
+         ;;!!!ACR CHANGE!!! precacl_dmmodcp is a pre_calcuated array
+         ;;that saves lots of time, see !!!ACR above
+         ;;The original version of the line pre !!!ACR
+         ;;crats = 1./reform(params[2, *, *])*reform(t3sim.t3phi#dm#modcp, nr, nang)/norm
+      endelse
      ;;The following formula is a crude correction for using this
      ;;high-contrast limit formula for low contrast and separation.
      ;;... we have to invert:


### PR DESCRIPTION
calibrate_v2_cp.pro : carry the starlist keyword through

skygauss.pro: removed a slow loop that can be done in the matrix. Significant for VLT/NACO data with lots of frames. Also added code to suppress floating underflows from being printed.

ic_jdm.pro: Seemed to be missing from the repository but needed by binary_grid.pro, added it from an older version of the code.

binary_grid.pro: Sped up the simulation part by precalculating some stuff.
